### PR TITLE
<fix> Issue #17 - Limited SDK & Flutter versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,52 +1,18 @@
 name: asuka
-description: Show Snackbars, dialogs, ModalSheets in a single provider. Simple and Clean.
-version: 2.0.0
+description: Show Snackbars, Dialogs, ModalSheets in a single provider. Simple and Clean.
+version: 2.0.0+2
 homepage: https://github.com/Flutterando/asuka
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-
+  sdk: ">=2.14.0-0 <3.0.0"
+  flutter: ">=2.3.0 <4.0.0"
+  
 dependencies:
   flutter:
-    sdk: flutter
-
+    sdk: flutter 
+    
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
Changed Dart SDK to a minimum of 2.14.0 and placed a range for valid Flutter versions from 2.3.0 to 4.0.0